### PR TITLE
Replace long with time_t

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,7 @@ void packet_handler_ex(const struct pcap_pkthdr* header, const u_char* pkt_data,
         if (handle == NULL || pcap_sendpacket(handle, pkt_data, header->len) != 0)
         {
             //error detected
-            long nowTime;
+            time_t nowTime;
             time(&nowTime);
             if (nowTime - cfg.init_time > ERRTIMEOUT && header->len < 1500)
             {
@@ -282,7 +282,7 @@ void packet_handler_ex(const struct pcap_pkthdr* header, const u_char* pkt_data,
             if (handle == NULL || pcap_sendpacket(handle, buf, header->len) != 0)
             {
                 //error detected
-                long nowTime;
+                time_t nowTime;
                 time(&nowTime);
                 if (nowTime - cfg.init_time > ERRTIMEOUT && header->len < 1500)
                 {


### PR DESCRIPTION
Fixes compilation error with 64-bit time_t.